### PR TITLE
new: allow `async` as a modifier

### DIFF
--- a/src/parser/internal/definition/function.rs
+++ b/src/parser/internal/definition/function.rs
@@ -17,14 +17,10 @@ use crate::tree::definition::function::MethodTypeConstraintGroupDefinition;
 use crate::tree::definition::modifier::ModifierGroupDefinition;
 
 pub fn function_definition(state: &mut State) -> ParseResult<FunctionDefinition> {
-    let comments = state.iterator.comments();
-    let attributes = state.get_attributes();
-    let modifiers = modifier::collect(state)?;
-
     Ok(FunctionDefinition {
-        comments,
-        attributes,
-        modifiers,
+        comments: state.iterator.comments(),
+        attributes: state.get_attributes(),
+        modifiers: modifier::collect_some(state)?,
         function: utils::skip_keyword(state, TokenKind::Function)?,
         name: identifier::identifier_maybe_soft_reserved(state)?,
         templates: if state.iterator.current().kind == TokenKind::LessThan {

--- a/src/parser/internal/definition/function.rs
+++ b/src/parser/internal/definition/function.rs
@@ -20,7 +20,7 @@ pub fn function_definition(state: &mut State) -> ParseResult<FunctionDefinition>
     Ok(FunctionDefinition {
         comments: state.iterator.comments(),
         attributes: state.get_attributes(),
-        modifiers: modifier::collect_some(state)?,
+        modifiers: modifier::collect(state)?,
         function: utils::skip_keyword(state, TokenKind::Function)?,
         name: identifier::identifier_maybe_soft_reserved(state)?,
         templates: if state.iterator.current().kind == TokenKind::LessThan {

--- a/src/parser/internal/definition/function.rs
+++ b/src/parser/internal/definition/function.rs
@@ -1,4 +1,5 @@
 use crate::lexer::token::TokenKind;
+use crate::parser::internal::definition::modifier;
 use crate::parser::internal::definition::parameter;
 use crate::parser::internal::definition::r#type;
 use crate::parser::internal::definition::template;
@@ -18,10 +19,12 @@ use crate::tree::definition::modifier::ModifierGroupDefinition;
 pub fn function_definition(state: &mut State) -> ParseResult<FunctionDefinition> {
     let comments = state.iterator.comments();
     let attributes = state.get_attributes();
+    let modifiers = modifier::collect(state)?;
 
     Ok(FunctionDefinition {
         comments,
         attributes,
+        modifiers,
         function: utils::skip_keyword(state, TokenKind::Function)?,
         name: identifier::identifier_maybe_soft_reserved(state)?,
         templates: if state.iterator.current().kind == TokenKind::LessThan {

--- a/src/parser/internal/definition/mod.rs
+++ b/src/parser/internal/definition/mod.rs
@@ -76,7 +76,7 @@ pub fn definition(state: &mut State) -> ParseResult<Definition> {
         )));
     }
 
-    if current.kind == TokenKind::Function {
+    if matches!(current.kind, TokenKind::Async | TokenKind::Function) {
         return Ok(Definition::Function(Box::new(
             function::function_definition(state)?,
         )));

--- a/src/parser/internal/definition/modifier.rs
+++ b/src/parser/internal/definition/modifier.rs
@@ -61,10 +61,3 @@ pub fn collect(state: &mut State) -> ParseResult<ModifierGroupDefinition> {
         modifiers,
     })
 }
-
-pub fn collect_some(state: &mut State) -> ParseResult<Option<ModifierGroupDefinition>> {
-    match collect(state) {
-        Ok(modifiers) if !modifiers.modifiers.is_empty() => Ok(Some(modifiers)),
-        _ => Ok(None),
-    }
-}

--- a/src/parser/internal/definition/modifier.rs
+++ b/src/parser/internal/definition/modifier.rs
@@ -15,6 +15,7 @@ pub fn collect(state: &mut State) -> ParseResult<ModifierGroupDefinition> {
         TokenKind::Abstract,
         TokenKind::Static,
         TokenKind::Readonly,
+        TokenKind::Async,
     ];
 
     let mut current = state.iterator.current().clone();
@@ -43,6 +44,9 @@ pub fn collect(state: &mut State) -> ParseResult<ModifierGroupDefinition> {
             }
             TokenKind::Readonly => {
                 ModifierDefinition::Readonly(utils::skip_keyword(state, TokenKind::Readonly)?)
+            }
+            TokenKind::Async => {
+                ModifierDefinition::Async(utils::skip_keyword(state, TokenKind::Async)?)
             }
             _ => unreachable!(),
         });

--- a/src/parser/internal/definition/modifier.rs
+++ b/src/parser/internal/definition/modifier.rs
@@ -61,3 +61,10 @@ pub fn collect(state: &mut State) -> ParseResult<ModifierGroupDefinition> {
         modifiers,
     })
 }
+
+pub fn collect_some(state: &mut State) -> ParseResult<Option<ModifierGroupDefinition>> {
+    match collect(state) {
+        Ok(modifiers) if !modifiers.modifiers.is_empty() => Ok(Some(modifiers)),
+        _ => Ok(None),
+    }
+}

--- a/src/parser/internal/expression/function.rs
+++ b/src/parser/internal/expression/function.rs
@@ -1,4 +1,5 @@
 use crate::lexer::token::TokenKind;
+use crate::parser::internal::definition::modifier;
 use crate::parser::internal::definition::parameter;
 use crate::parser::internal::definition::r#type;
 use crate::parser::internal::expression;
@@ -18,12 +19,7 @@ pub fn anonymous_function_expression(
 ) -> ParseResult<AnonymousFunctionExpression> {
     let comments = state.iterator.comments();
     let attributes = state.get_attributes();
-    let current = state.iterator.current();
-    let r#static = if current.kind == TokenKind::Static {
-        Some(utils::skip_keyword(state, TokenKind::Static)?)
-    } else {
-        None
-    };
+    let modifiers = modifier::collect(state)?;
 
     let function = utils::skip_keyword(state, TokenKind::Function)?;
     let parameters = parameter::function_like_parameter_list_definition(state)?;
@@ -55,9 +51,9 @@ pub fn anonymous_function_expression(
 
     Ok(AnonymousFunctionExpression {
         comments,
-        r#static,
-        function,
         attributes,
+        modifiers,
+        function,
         parameters,
         use_clause: uses,
         return_type: FunctionLikeReturnTypeDefinition {
@@ -69,19 +65,14 @@ pub fn anonymous_function_expression(
 }
 
 pub fn arrow_function_expression(state: &mut State) -> ParseResult<ArrowFunctionExpression> {
-    let current = state.iterator.current();
-
     let comments = state.iterator.comments();
     let attributes = state.get_attributes();
+    let modifiers = modifier::collect(state)?;
 
     Ok(ArrowFunctionExpression {
         comments,
         attributes,
-        r#static: if current.kind == TokenKind::Static {
-            Some(utils::skip_keyword(state, TokenKind::Static)?)
-        } else {
-            None
-        },
+        modifiers,
         r#fn: utils::skip_keyword(state, TokenKind::Fn)?,
         parameters: parameter::function_like_parameter_list_definition(state)?,
         return_type: FunctionLikeReturnTypeDefinition {

--- a/src/tree/definition/function.rs
+++ b/src/tree/definition/function.rs
@@ -54,7 +54,7 @@ pub struct FunctionLikeParameterListDefinition {
 pub struct FunctionDefinition {
     pub attributes: Vec<AttributeGroupDefinition>,
     pub comments: CommentGroup,
-    pub modifiers: Option<ModifierGroupDefinition>,
+    pub modifiers: ModifierGroupDefinition,
     pub function: Keyword,
     pub name: Identifier,
     pub templates: Option<TemplateGroupDefinition>,
@@ -254,6 +254,7 @@ impl Node for FunctionDefinition {
             children.push(templates);
         }
 
+        children.push(&self.modifiers);
         children.push(&self.parameters);
         children.push(&self.return_type);
         children.push(&self.body);

--- a/src/tree/definition/function.rs
+++ b/src/tree/definition/function.rs
@@ -54,7 +54,7 @@ pub struct FunctionLikeParameterListDefinition {
 pub struct FunctionDefinition {
     pub attributes: Vec<AttributeGroupDefinition>,
     pub comments: CommentGroup,
-    pub modifiers: ModifierGroupDefinition,
+    pub modifiers: Option<ModifierGroupDefinition>,
     pub function: Keyword,
     pub name: Identifier,
     pub templates: Option<TemplateGroupDefinition>,

--- a/src/tree/definition/function.rs
+++ b/src/tree/definition/function.rs
@@ -52,8 +52,9 @@ pub struct FunctionLikeParameterListDefinition {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct FunctionDefinition {
-    pub comments: CommentGroup,
     pub attributes: Vec<AttributeGroupDefinition>,
+    pub comments: CommentGroup,
+    pub modifiers: ModifierGroupDefinition,
     pub function: Keyword,
     pub name: Identifier,
     pub templates: Option<TemplateGroupDefinition>,

--- a/src/tree/definition/modifier.rs
+++ b/src/tree/definition/modifier.rs
@@ -15,6 +15,7 @@ pub enum ModifierDefinition {
     Readonly(Keyword),
     Final(Keyword),
     Abstract(Keyword),
+    Async(Keyword),
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -60,6 +61,7 @@ impl Node for ModifierDefinition {
             | Self::Readonly(keyword)
             | Self::Static(keyword)
             | Self::Abstract(keyword)
+            | Self::Async(keyword)
             | Self::Final(keyword) => keyword.initial_position(),
         }
     }
@@ -72,6 +74,7 @@ impl Node for ModifierDefinition {
             | Self::Readonly(keyword)
             | Self::Static(keyword)
             | Self::Abstract(keyword)
+            | Self::Async(keyword)
             | Self::Final(keyword) => keyword.final_position(),
         }
     }
@@ -84,6 +87,7 @@ impl Node for ModifierDefinition {
             | Self::Readonly(keyword)
             | Self::Static(keyword)
             | Self::Abstract(keyword)
+            | Self::Async(keyword)
             | Self::Final(keyword) => vec![keyword as &dyn Node],
         }
     }
@@ -96,6 +100,7 @@ impl Node for ModifierDefinition {
             Self::Readonly(_keyword) => "readonly modifier definition".to_string(),
             Self::Static(_keyword) => "static modifier definition".to_string(),
             Self::Abstract(_keyword) => "abstract modifier definition".to_string(),
+            Self::Async(_keyword) => "async modifier definition".to_string(),
             Self::Final(_keyword) => "final modifier definition".to_string(),
         }
     }
@@ -110,6 +115,7 @@ impl std::fmt::Display for ModifierDefinition {
             | Self::Readonly(keyword)
             | Self::Static(keyword)
             | Self::Abstract(keyword)
+            | Self::Async(keyword)
             | Self::Final(keyword) => write!(f, "{}", keyword.value),
         }
     }

--- a/src/tree/expression/function.rs
+++ b/src/tree/expression/function.rs
@@ -6,6 +6,7 @@ use crate::tree::comment::CommentGroup;
 use crate::tree::definition::attribute::AttributeGroupDefinition;
 use crate::tree::definition::function::FunctionLikeParameterListDefinition;
 use crate::tree::definition::function::FunctionLikeReturnTypeDefinition;
+use crate::tree::definition::modifier::ModifierGroupDefinition;
 use crate::tree::expression::Expression;
 use crate::tree::statement::block::BlockStatement;
 use crate::tree::token::Keyword;
@@ -18,7 +19,7 @@ use crate::tree::Node;
 pub struct ArrowFunctionExpression {
     pub comments: CommentGroup,
     pub attributes: Vec<AttributeGroupDefinition>,
-    pub r#static: Option<Keyword>,
+    pub modifiers: ModifierGroupDefinition,
     pub r#fn: Keyword,
     pub parameters: FunctionLikeParameterListDefinition,
     pub return_type: FunctionLikeReturnTypeDefinition,
@@ -31,7 +32,7 @@ pub struct ArrowFunctionExpression {
 pub struct AnonymousFunctionExpression {
     pub comments: CommentGroup,
     pub attributes: Vec<AttributeGroupDefinition>,
-    pub r#static: Option<Keyword>,
+    pub modifiers: ModifierGroupDefinition,
     pub function: Keyword,
     pub parameters: FunctionLikeParameterListDefinition,
     pub use_clause: Option<AnonymousFunctionUseClauseExpression>,
@@ -66,8 +67,8 @@ impl Node for ArrowFunctionExpression {
             return attribute.initial_position();
         }
 
-        if let Some(r#static) = &self.r#static {
-            return r#static.initial_position();
+        if !&self.modifiers.modifiers.is_empty() {
+            return self.modifiers.initial_position();
         }
 
         self.r#fn.initial_position()
@@ -84,12 +85,8 @@ impl Node for ArrowFunctionExpression {
             children.push(attribute);
         }
 
-        if let Some(r#static) = &self.r#static {
-            children.push(r#static);
-        }
-
         children.push(&self.r#fn);
-
+        children.push(&self.modifiers);
         children.push(&self.parameters);
         children.push(&self.return_type);
         children.push(self.body.as_ref());
@@ -112,8 +109,8 @@ impl Node for AnonymousFunctionExpression {
             return attribute.initial_position();
         }
 
-        if let Some(r#static) = &self.r#static {
-            return r#static.initial_position();
+        if !&self.modifiers.modifiers.is_empty() {
+            return self.modifiers.initial_position();
         }
 
         self.function.initial_position()
@@ -130,11 +127,8 @@ impl Node for AnonymousFunctionExpression {
             children.push(attribute);
         }
 
-        if let Some(r#static) = &self.r#static {
-            children.push(r#static);
-        }
-
         children.push(&self.function);
+        children.push(&self.modifiers);
         children.push(&self.parameters);
         children.push(&self.return_type);
         children.push(&self.body);

--- a/tests/samples/0001/tree.txt
+++ b/tests/samples/0001/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0001/tree.txt
+++ b/tests/samples/0001/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0001/tree.txt
+++ b/tests/samples/0001/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0002/tree.txt
+++ b/tests/samples/0002/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0002/tree.txt
+++ b/tests/samples/0002/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0002/tree.txt
+++ b/tests/samples/0002/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0004/tree.txt
+++ b/tests/samples/0004/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0004/tree.txt
+++ b/tests/samples/0004/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0004/tree.txt
+++ b/tests/samples/0004/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0005/tree.txt
+++ b/tests/samples/0005/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0005/tree.txt
+++ b/tests/samples/0005/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0005/tree.txt
+++ b/tests/samples/0005/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0006/tree.txt
+++ b/tests/samples/0006/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0006/tree.txt
+++ b/tests/samples/0006/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0006/tree.txt
+++ b/tests/samples/0006/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0007/tree.txt
+++ b/tests/samples/0007/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0007/tree.txt
+++ b/tests/samples/0007/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0007/tree.txt
+++ b/tests/samples/0007/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0008/tree.txt
+++ b/tests/samples/0008/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0008/tree.txt
+++ b/tests/samples/0008/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0008/tree.txt
+++ b/tests/samples/0008/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0009/tree.txt
+++ b/tests/samples/0009/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0009/tree.txt
+++ b/tests/samples/0009/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0009/tree.txt
+++ b/tests/samples/0009/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0010/tree.txt
+++ b/tests/samples/0010/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0010/tree.txt
+++ b/tests/samples/0010/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0010/tree.txt
+++ b/tests/samples/0010/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0011/tree.txt
+++ b/tests/samples/0011/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0011/tree.txt
+++ b/tests/samples/0011/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0011/tree.txt
+++ b/tests/samples/0011/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0012/tree.txt
+++ b/tests/samples/0012/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0012/tree.txt
+++ b/tests/samples/0012/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0012/tree.txt
+++ b/tests/samples/0012/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0013/tree.txt
+++ b/tests/samples/0013/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0013/tree.txt
+++ b/tests/samples/0013/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0013/tree.txt
+++ b/tests/samples/0013/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0014/tree.txt
+++ b/tests/samples/0014/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0014/tree.txt
+++ b/tests/samples/0014/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0014/tree.txt
+++ b/tests/samples/0014/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0015/tree.txt
+++ b/tests/samples/0015/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0015/tree.txt
+++ b/tests/samples/0015/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0015/tree.txt
+++ b/tests/samples/0015/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0016/tree.txt
+++ b/tests/samples/0016/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0016/tree.txt
+++ b/tests/samples/0016/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0016/tree.txt
+++ b/tests/samples/0016/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0017/tree.txt
+++ b/tests/samples/0017/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0017/tree.txt
+++ b/tests/samples/0017/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0017/tree.txt
+++ b/tests/samples/0017/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0021/tree.txt
+++ b/tests/samples/0021/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0021/tree.txt
+++ b/tests/samples/0021/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0021/tree.txt
+++ b/tests/samples/0021/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0022/tree.txt
+++ b/tests/samples/0022/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0022/tree.txt
+++ b/tests/samples/0022/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0022/tree.txt
+++ b/tests/samples/0022/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0024/tree.txt
+++ b/tests/samples/0024/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0024/tree.txt
+++ b/tests/samples/0024/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0024/tree.txt
+++ b/tests/samples/0024/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0026/tree.txt
+++ b/tests/samples/0026/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 2,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 2,

--- a/tests/samples/0026/tree.txt
+++ b/tests/samples/0026/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 2,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 2,

--- a/tests/samples/0026/tree.txt
+++ b/tests/samples/0026/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 2,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 2,

--- a/tests/samples/0027/tree.txt
+++ b/tests/samples/0027/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0027/tree.txt
+++ b/tests/samples/0027/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0027/tree.txt
+++ b/tests/samples/0027/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0031/tree.txt
+++ b/tests/samples/0031/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0031/tree.txt
+++ b/tests/samples/0031/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0031/tree.txt
+++ b/tests/samples/0031/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0032/tree.txt
+++ b/tests/samples/0032/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0032/tree.txt
+++ b/tests/samples/0032/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0032/tree.txt
+++ b/tests/samples/0032/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0037/tree.txt
+++ b/tests/samples/0037/tree.txt
@@ -18,7 +18,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 22,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0037/tree.txt
+++ b/tests/samples/0037/tree.txt
@@ -14,10 +14,14 @@ DefinitionTree {
                 definitions: [
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 22,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0037/tree.txt
+++ b/tests/samples/0037/tree.txt
@@ -18,10 +18,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 22,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0038/tree.txt
+++ b/tests/samples/0038/tree.txt
@@ -18,7 +18,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 22,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0038/tree.txt
+++ b/tests/samples/0038/tree.txt
@@ -14,10 +14,14 @@ DefinitionTree {
                 definitions: [
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 22,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0038/tree.txt
+++ b/tests/samples/0038/tree.txt
@@ -18,10 +18,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 22,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0039/tree.txt
+++ b/tests/samples/0039/tree.txt
@@ -18,7 +18,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 22,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0039/tree.txt
+++ b/tests/samples/0039/tree.txt
@@ -14,10 +14,14 @@ DefinitionTree {
                 definitions: [
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 22,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0039/tree.txt
+++ b/tests/samples/0039/tree.txt
@@ -18,10 +18,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 22,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 22,

--- a/tests/samples/0042/tree.txt
+++ b/tests/samples/0042/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0042/tree.txt
+++ b/tests/samples/0042/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0042/tree.txt
+++ b/tests/samples/0042/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0051/tree.txt
+++ b/tests/samples/0051/tree.txt
@@ -94,10 +94,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 61,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 61,

--- a/tests/samples/0051/tree.txt
+++ b/tests/samples/0051/tree.txt
@@ -98,7 +98,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 61,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 61,

--- a/tests/samples/0051/tree.txt
+++ b/tests/samples/0051/tree.txt
@@ -98,10 +98,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 61,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 61,

--- a/tests/samples/0052/tree.txt
+++ b/tests/samples/0052/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0052/tree.txt
+++ b/tests/samples/0052/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0052/tree.txt
+++ b/tests/samples/0052/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0053/tree.txt
+++ b/tests/samples/0053/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0053/tree.txt
+++ b/tests/samples/0053/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0053/tree.txt
+++ b/tests/samples/0053/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0054/tree.txt
+++ b/tests/samples/0054/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0054/tree.txt
+++ b/tests/samples/0054/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0054/tree.txt
+++ b/tests/samples/0054/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0056/tree.txt
+++ b/tests/samples/0056/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,
@@ -55,10 +52,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 25,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 25,
@@ -104,10 +98,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 51,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 51,
@@ -153,10 +144,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 76,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 76,
@@ -202,10 +190,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 105,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 105,
@@ -251,10 +236,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 130,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 130,
@@ -300,10 +282,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 157,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 157,
@@ -349,10 +328,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 182,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 182,
@@ -398,10 +374,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 208,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 208,

--- a/tests/samples/0056/tree.txt
+++ b/tests/samples/0056/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,
@@ -47,10 +51,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 25,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 25,
@@ -92,10 +100,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 51,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 51,
@@ -137,10 +149,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 76,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 76,
@@ -182,10 +198,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 105,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 105,
@@ -227,10 +247,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 130,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 130,
@@ -272,10 +296,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 157,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 157,
@@ -317,10 +345,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 182,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 182,
@@ -362,10 +394,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 208,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 208,

--- a/tests/samples/0056/tree.txt
+++ b/tests/samples/0056/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,
@@ -52,7 +55,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 25,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 25,
@@ -98,7 +104,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 51,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 51,
@@ -144,7 +153,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 76,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 76,
@@ -190,7 +202,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 105,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 105,
@@ -236,7 +251,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 130,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 130,
@@ -282,7 +300,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 157,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 157,
@@ -328,7 +349,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 182,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 182,
@@ -374,7 +398,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 208,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 208,

--- a/tests/samples/0061/tree.txt
+++ b/tests/samples/0061/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0061/tree.txt
+++ b/tests/samples/0061/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0061/tree.txt
+++ b/tests/samples/0061/tree.txt
@@ -79,7 +79,10 @@ DefinitionTree {
                                                                     comments: [],
                                                                 },
                                                                 attributes: [],
-                                                                static: None,
+                                                                modifiers: ModifierGroupDefinition {
+                                                                    position: 31,
+                                                                    modifiers: [],
+                                                                },
                                                                 fn: Keyword {
                                                                     value: "fn",
                                                                     position: 31,

--- a/tests/samples/0061/tree.txt
+++ b/tests/samples/0061/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0063/tree.txt
+++ b/tests/samples/0063/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0063/tree.txt
+++ b/tests/samples/0063/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0063/tree.txt
+++ b/tests/samples/0063/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0066/tree.txt
+++ b/tests/samples/0066/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0066/tree.txt
+++ b/tests/samples/0066/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0066/tree.txt
+++ b/tests/samples/0066/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0069/tree.txt
+++ b/tests/samples/0069/tree.txt
@@ -43,7 +43,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 40,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 40,
@@ -382,7 +385,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 188,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 188,

--- a/tests/samples/0069/tree.txt
+++ b/tests/samples/0069/tree.txt
@@ -39,10 +39,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 40,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 40,
@@ -377,10 +381,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 188,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 188,

--- a/tests/samples/0069/tree.txt
+++ b/tests/samples/0069/tree.txt
@@ -245,7 +245,10 @@ DefinitionTree {
                                                                                 comments: [],
                                                                             },
                                                                             attributes: [],
-                                                                            static: None,
+                                                                            modifiers: ModifierGroupDefinition {
+                                                                                position: 120,
+                                                                                modifiers: [],
+                                                                            },
                                                                             fn: Keyword {
                                                                                 value: "fn",
                                                                                 position: 120,
@@ -551,7 +554,10 @@ DefinitionTree {
                                                                                 comments: [],
                                                                             },
                                                                             attributes: [],
-                                                                            static: None,
+                                                                            modifiers: ModifierGroupDefinition {
+                                                                                position: 251,
+                                                                                modifiers: [],
+                                                                            },
                                                                             fn: Keyword {
                                                                                 value: "fn",
                                                                                 position: 251,

--- a/tests/samples/0069/tree.txt
+++ b/tests/samples/0069/tree.txt
@@ -43,10 +43,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 40,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 40,
@@ -385,10 +382,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 188,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 188,

--- a/tests/samples/0070/tree.txt
+++ b/tests/samples/0070/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0070/tree.txt
+++ b/tests/samples/0070/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0070/tree.txt
+++ b/tests/samples/0070/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0071/tree.txt
+++ b/tests/samples/0071/tree.txt
@@ -114,10 +114,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 79,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 79,
@@ -258,10 +255,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 134,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 134,
@@ -446,10 +440,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 220,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 220,
@@ -919,10 +910,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 448,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 448,
@@ -1120,10 +1108,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 517,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 517,
@@ -1283,10 +1268,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 591,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 591,
@@ -1858,10 +1840,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 837,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 837,
@@ -2133,10 +2112,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 999,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 999,
@@ -2440,10 +2416,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1190,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1190,

--- a/tests/samples/0071/tree.txt
+++ b/tests/samples/0071/tree.txt
@@ -110,10 +110,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 79,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 79,
@@ -250,10 +254,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 134,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 134,
@@ -434,10 +442,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 220,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 220,
@@ -903,10 +915,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 448,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 448,
@@ -1100,10 +1116,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 517,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 517,
@@ -1259,10 +1279,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 591,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 591,
@@ -1830,10 +1854,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 837,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 837,
@@ -2101,10 +2129,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 999,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 999,
@@ -2404,10 +2436,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1190,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1190,

--- a/tests/samples/0071/tree.txt
+++ b/tests/samples/0071/tree.txt
@@ -114,7 +114,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 79,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 79,
@@ -255,7 +258,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 134,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 134,
@@ -440,7 +446,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 220,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 220,
@@ -910,7 +919,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 448,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 448,
@@ -1108,7 +1120,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 517,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 517,
@@ -1268,7 +1283,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 591,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 591,
@@ -1840,7 +1858,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 837,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 837,
@@ -2112,7 +2133,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 999,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 999,
@@ -2416,7 +2440,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1190,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1190,

--- a/tests/samples/0072/tree.txt
+++ b/tests/samples/0072/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0072/tree.txt
+++ b/tests/samples/0072/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0072/tree.txt
+++ b/tests/samples/0072/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0073/tree.txt
+++ b/tests/samples/0073/tree.txt
@@ -89,10 +89,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 41,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 41,
@@ -631,10 +635,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 326,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 326,

--- a/tests/samples/0073/tree.txt
+++ b/tests/samples/0073/tree.txt
@@ -93,7 +93,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 41,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 41,
@@ -636,7 +639,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 326,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 326,

--- a/tests/samples/0073/tree.txt
+++ b/tests/samples/0073/tree.txt
@@ -93,10 +93,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 41,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 41,
@@ -639,10 +636,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 326,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 326,

--- a/tests/samples/0074/tree.txt
+++ b/tests/samples/0074/tree.txt
@@ -51,10 +51,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 45,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 45,
@@ -503,10 +507,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 356,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 356,
@@ -601,10 +609,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 421,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 421,

--- a/tests/samples/0074/tree.txt
+++ b/tests/samples/0074/tree.txt
@@ -55,7 +55,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 45,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 45,
@@ -508,7 +511,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 356,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 356,
@@ -607,7 +613,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 421,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 421,

--- a/tests/samples/0074/tree.txt
+++ b/tests/samples/0074/tree.txt
@@ -55,10 +55,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 45,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 45,
@@ -511,10 +508,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 356,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 356,
@@ -613,10 +607,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 421,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 421,

--- a/tests/samples/0075/tree.txt
+++ b/tests/samples/0075/tree.txt
@@ -1268,7 +1268,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 839,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 839,

--- a/tests/samples/0075/tree.txt
+++ b/tests/samples/0075/tree.txt
@@ -1578,7 +1578,10 @@ DefinitionTree {
                                                                                     comments: [],
                                                                                 },
                                                                                 attributes: [],
-                                                                                static: None,
+                                                                                modifiers: ModifierGroupDefinition {
+                                                                                    position: 993,
+                                                                                    modifiers: [],
+                                                                                },
                                                                                 fn: Keyword {
                                                                                     value: "fn",
                                                                                     position: 993,
@@ -1702,7 +1705,10 @@ DefinitionTree {
                                                                             comments: [],
                                                                         },
                                                                         attributes: [],
-                                                                        static: None,
+                                                                        modifiers: ModifierGroupDefinition {
+                                                                            position: 1051,
+                                                                            modifiers: [],
+                                                                        },
                                                                         fn: Keyword {
                                                                             value: "fn",
                                                                             position: 1051,

--- a/tests/samples/0075/tree.txt
+++ b/tests/samples/0075/tree.txt
@@ -1264,10 +1264,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 839,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 839,

--- a/tests/samples/0075/tree.txt
+++ b/tests/samples/0075/tree.txt
@@ -1268,10 +1268,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 839,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 839,

--- a/tests/samples/0076/tree.txt
+++ b/tests/samples/0076/tree.txt
@@ -215,7 +215,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 143,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 143,
@@ -617,7 +620,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 386,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 386,
@@ -891,7 +897,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 560,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 560,
@@ -1293,7 +1302,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 779,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 779,

--- a/tests/samples/0076/tree.txt
+++ b/tests/samples/0076/tree.txt
@@ -215,10 +215,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 143,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 143,
@@ -620,10 +617,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 386,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 386,
@@ -897,10 +891,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 560,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 560,
@@ -1302,10 +1293,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 779,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 779,

--- a/tests/samples/0076/tree.txt
+++ b/tests/samples/0076/tree.txt
@@ -211,10 +211,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 143,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 143,
@@ -612,10 +616,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 386,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 386,
@@ -885,10 +893,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 560,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 560,
@@ -1286,10 +1298,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 779,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 779,

--- a/tests/samples/0078/tree.txt
+++ b/tests/samples/0078/tree.txt
@@ -348,10 +348,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 149,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 149,
@@ -716,10 +713,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 372,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 372,
@@ -1130,10 +1124,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 575,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 575,
@@ -1541,10 +1532,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 825,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 825,
@@ -2008,10 +1996,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1060,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1060,
@@ -2476,10 +2461,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1328,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1328,

--- a/tests/samples/0078/tree.txt
+++ b/tests/samples/0078/tree.txt
@@ -348,7 +348,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 149,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 149,
@@ -713,7 +716,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 372,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 372,
@@ -1124,7 +1130,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 575,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 575,
@@ -1532,7 +1541,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 825,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 825,
@@ -1996,7 +2008,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1060,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1060,
@@ -2461,7 +2476,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1328,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1328,

--- a/tests/samples/0078/tree.txt
+++ b/tests/samples/0078/tree.txt
@@ -344,10 +344,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 149,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 149,
@@ -708,10 +712,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 372,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 372,
@@ -1118,10 +1126,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 575,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 575,
@@ -1525,10 +1537,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 825,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 825,
@@ -1988,10 +2004,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1060,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1060,
@@ -2452,10 +2472,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1328,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1328,

--- a/tests/samples/0079/tree.txt
+++ b/tests/samples/0079/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0079/tree.txt
+++ b/tests/samples/0079/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0079/tree.txt
+++ b/tests/samples/0079/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1,

--- a/tests/samples/0081/tree.txt
+++ b/tests/samples/0081/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0081/tree.txt
+++ b/tests/samples/0081/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0081/tree.txt
+++ b/tests/samples/0081/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0082/code.ara
+++ b/tests/samples/0082/code.ara
@@ -43,7 +43,7 @@ function example(): int {
     $collection
       ->filter(fn(num $n): bool => $n < 8)
       ->map::<float>(
-        fn(num $n): float => $n is float ? $n : $n + 0.0
+        static fn(num $n): float => $n is float ? $n : $n + 0.0
       )
       ->sum()
 }

--- a/tests/samples/0082/tree.txt
+++ b/tests/samples/0082/tree.txt
@@ -1268,7 +1268,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 839,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 839,

--- a/tests/samples/0082/tree.txt
+++ b/tests/samples/0082/tree.txt
@@ -1578,7 +1578,10 @@ DefinitionTree {
                                                                                     comments: [],
                                                                                 },
                                                                                 attributes: [],
-                                                                                static: None,
+                                                                                modifiers: ModifierGroupDefinition {
+                                                                                    position: 993,
+                                                                                    modifiers: [],
+                                                                                },
                                                                                 fn: Keyword {
                                                                                     value: "fn",
                                                                                     position: 993,
@@ -1702,16 +1705,26 @@ DefinitionTree {
                                                                             comments: [],
                                                                         },
                                                                         attributes: [],
-                                                                        static: None,
+                                                                        modifiers: ModifierGroupDefinition {
+                                                                            position: 1058,
+                                                                            modifiers: [
+                                                                                Static(
+                                                                                    Keyword {
+                                                                                        value: "static",
+                                                                                        position: 1051,
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
                                                                         fn: Keyword {
                                                                             value: "fn",
-                                                                            position: 1051,
+                                                                            position: 1058,
                                                                         },
                                                                         parameters: FunctionLikeParameterListDefinition {
                                                                             comments: CommentGroup {
                                                                                 comments: [],
                                                                             },
-                                                                            left_parenthesis: 1053,
+                                                                            left_parenthesis: 1060,
                                                                             parameters: CommaSeparated {
                                                                                 inner: [
                                                                                     FunctionLikeParameterDefinition {
@@ -1722,7 +1735,7 @@ DefinitionTree {
                                                                                         type_definition: Identifier(
                                                                                             TemplatedIdentifier {
                                                                                                 name: Identifier {
-                                                                                                    position: 1054,
+                                                                                                    position: 1061,
                                                                                                     value: "num",
                                                                                                 },
                                                                                                 templates: None,
@@ -1730,7 +1743,7 @@ DefinitionTree {
                                                                                         ),
                                                                                         ellipsis: None,
                                                                                         variable: Variable {
-                                                                                            position: 1058,
+                                                                                            position: 1065,
                                                                                             name: "$n",
                                                                                         },
                                                                                         default: None,
@@ -1738,20 +1751,20 @@ DefinitionTree {
                                                                                 ],
                                                                                 commas: [],
                                                                             },
-                                                                            right_parenthesis: 1060,
+                                                                            right_parenthesis: 1067,
                                                                         },
                                                                         return_type: FunctionLikeReturnTypeDefinition {
-                                                                            colon: 1061,
+                                                                            colon: 1068,
                                                                             type_definition: FloatingPoint(
                                                                                 Default(
                                                                                     Keyword {
                                                                                         value: "float",
-                                                                                        position: 1063,
+                                                                                        position: 1070,
                                                                                     },
                                                                                 ),
                                                                             ),
                                                                         },
-                                                                        double_arrow: 1069,
+                                                                        double_arrow: 1076,
                                                                         body: TernaryOperation(
                                                                             Ternary {
                                                                                 comments: CommentGroup {
@@ -1764,32 +1777,32 @@ DefinitionTree {
                                                                                         },
                                                                                         left: Variable(
                                                                                             Variable {
-                                                                                                position: 1072,
+                                                                                                position: 1079,
                                                                                                 name: "$n",
                                                                                             },
                                                                                         ),
                                                                                         is: Keyword {
                                                                                             value: "is",
-                                                                                            position: 1075,
+                                                                                            position: 1082,
                                                                                         },
                                                                                         right: FloatingPoint(
                                                                                             Default(
                                                                                                 Keyword {
                                                                                                     value: "float",
-                                                                                                    position: 1078,
+                                                                                                    position: 1085,
                                                                                                 },
                                                                                             ),
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                                question: 1084,
+                                                                                question: 1091,
                                                                                 if_true: Variable(
                                                                                     Variable {
-                                                                                        position: 1086,
+                                                                                        position: 1093,
                                                                                         name: "$n",
                                                                                     },
                                                                                 ),
-                                                                                colon: 1089,
+                                                                                colon: 1096,
                                                                                 if_false: ArithmeticOperation(
                                                                                     Addition {
                                                                                         comments: CommentGroup {
@@ -1797,11 +1810,11 @@ DefinitionTree {
                                                                                         },
                                                                                         left: Variable(
                                                                                             Variable {
-                                                                                                position: 1091,
+                                                                                                position: 1098,
                                                                                                 name: "$n",
                                                                                             },
                                                                                         ),
-                                                                                        plus: 1094,
+                                                                                        plus: 1101,
                                                                                         right: Literal(
                                                                                             Float(
                                                                                                 LiteralFloat {
@@ -1809,7 +1822,7 @@ DefinitionTree {
                                                                                                         comments: [],
                                                                                                     },
                                                                                                     value: "0.0",
-                                                                                                    position: 1096,
+                                                                                                    position: 1103,
                                                                                                 },
                                                                                             ),
                                                                                         ),
@@ -1823,13 +1836,13 @@ DefinitionTree {
                                                         ],
                                                         commas: [],
                                                     },
-                                                    right_parenthesis: 1106,
+                                                    right_parenthesis: 1113,
                                                 },
                                             },
                                         ),
-                                        arrow: 1114,
+                                        arrow: 1121,
                                         method: Identifier {
-                                            position: 1116,
+                                            position: 1123,
                                             value: "sum",
                                         },
                                         generics: None,
@@ -1837,22 +1850,22 @@ DefinitionTree {
                                             comments: CommentGroup {
                                                 comments: [],
                                             },
-                                            left_parenthesis: 1119,
+                                            left_parenthesis: 1126,
                                             arguments: CommaSeparated {
                                                 inner: [],
                                                 commas: [],
                                             },
-                                            right_parenthesis: 1120,
+                                            right_parenthesis: 1127,
                                         },
                                     },
                                 ),
                             },
                         ),
                     ],
-                    right_brace: 1122,
+                    right_brace: 1129,
                 },
             },
         ),
     ],
-    eof: 1123,
+    eof: 1130,
 }

--- a/tests/samples/0082/tree.txt
+++ b/tests/samples/0082/tree.txt
@@ -1264,10 +1264,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 839,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 839,

--- a/tests/samples/0082/tree.txt
+++ b/tests/samples/0082/tree.txt
@@ -1268,10 +1268,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 839,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 839,

--- a/tests/samples/0084/tree.txt
+++ b/tests/samples/0084/tree.txt
@@ -182,6 +182,7 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [
                         Comment {
@@ -191,7 +192,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 208,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 208,
@@ -468,6 +472,7 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [
                         Comment {
@@ -477,7 +482,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 406,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 406,
@@ -852,6 +860,7 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [
                         Comment {
@@ -861,7 +870,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 636,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 636,
@@ -1326,6 +1338,7 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [
                         Comment {
@@ -1335,7 +1348,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 884,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 884,
@@ -1602,6 +1618,7 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [
                         Comment {
@@ -1611,7 +1628,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 1097,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1097,

--- a/tests/samples/0084/tree.txt
+++ b/tests/samples/0084/tree.txt
@@ -192,10 +192,7 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 208,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 208,
@@ -482,10 +479,7 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 406,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 406,
@@ -870,10 +864,7 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 636,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 636,
@@ -1348,10 +1339,7 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 884,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 884,
@@ -1628,10 +1616,7 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 1097,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 1097,

--- a/tests/samples/0084/tree.txt
+++ b/tests/samples/0084/tree.txt
@@ -192,7 +192,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 208,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 208,
@@ -479,7 +482,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 406,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 406,
@@ -864,7 +870,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 636,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 636,
@@ -1339,7 +1348,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 884,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 884,
@@ -1616,7 +1628,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 1097,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 1097,

--- a/tests/samples/0085/tree.txt
+++ b/tests/samples/0085/tree.txt
@@ -1105,9 +1105,6 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
-                comments: CommentGroup {
-                    comments: [],
-                },
                 attributes: [
                     AttributeGroupDefinition {
                         hash_left_bracket: 502,
@@ -2120,6 +2117,13 @@ DefinitionTree {
                         right_bracket: 923,
                     },
                 ],
+                comments: CommentGroup {
+                    comments: [],
+                },
+                modifiers: ModifierGroupDefinition {
+                    position: 925,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 925,

--- a/tests/samples/0085/tree.txt
+++ b/tests/samples/0085/tree.txt
@@ -2120,10 +2120,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 925,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 925,

--- a/tests/samples/0085/tree.txt
+++ b/tests/samples/0085/tree.txt
@@ -2120,7 +2120,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 925,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 925,

--- a/tests/samples/0087/tree.txt
+++ b/tests/samples/0087/tree.txt
@@ -353,7 +353,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 281,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 281,
@@ -553,7 +556,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 380,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 380,

--- a/tests/samples/0087/tree.txt
+++ b/tests/samples/0087/tree.txt
@@ -343,6 +343,7 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [
                         Comment {
@@ -352,7 +353,10 @@ DefinitionTree {
                         },
                     ],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 281,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 281,
@@ -548,10 +552,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 380,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 380,

--- a/tests/samples/0087/tree.txt
+++ b/tests/samples/0087/tree.txt
@@ -353,10 +353,7 @@ DefinitionTree {
                         },
                     ],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 281,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 281,
@@ -556,10 +553,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 380,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 380,

--- a/tests/samples/0088/tree.txt
+++ b/tests/samples/0088/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0088/tree.txt
+++ b/tests/samples/0088/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0088/tree.txt
+++ b/tests/samples/0088/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0089/tree.txt
+++ b/tests/samples/0089/tree.txt
@@ -215,10 +215,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 125,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 125,
@@ -620,10 +617,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 296,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 296,

--- a/tests/samples/0089/tree.txt
+++ b/tests/samples/0089/tree.txt
@@ -211,10 +211,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 125,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 125,
@@ -612,10 +616,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 296,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 296,

--- a/tests/samples/0089/tree.txt
+++ b/tests/samples/0089/tree.txt
@@ -215,7 +215,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 125,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 125,
@@ -617,7 +620,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 296,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 296,

--- a/tests/samples/0090/tree.txt
+++ b/tests/samples/0090/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0090/tree.txt
+++ b/tests/samples/0090/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0090/tree.txt
+++ b/tests/samples/0090/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0091/tree.txt
+++ b/tests/samples/0091/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0091/tree.txt
+++ b/tests/samples/0091/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0091/tree.txt
+++ b/tests/samples/0091/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0093/tree.txt
+++ b/tests/samples/0093/tree.txt
@@ -215,7 +215,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 143,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 143,
@@ -617,7 +620,10 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: None,
+                            modifiers: ModifierGroupDefinition {
+                                position: 386,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 386,

--- a/tests/samples/0093/tree.txt
+++ b/tests/samples/0093/tree.txt
@@ -211,10 +211,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 143,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 143,
@@ -612,10 +616,14 @@ DefinitionTree {
                     ),
                     Function(
                         FunctionDefinition {
+                            attributes: [],
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            attributes: [],
+                            modifiers: ModifierGroupDefinition {
+                                position: 386,
+                                modifiers: [],
+                            },
                             function: Keyword {
                                 value: "function",
                                 position: 386,

--- a/tests/samples/0093/tree.txt
+++ b/tests/samples/0093/tree.txt
@@ -215,10 +215,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 143,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 143,
@@ -620,10 +617,7 @@ DefinitionTree {
                             comments: CommentGroup {
                                 comments: [],
                             },
-                            modifiers: ModifierGroupDefinition {
-                                position: 386,
-                                modifiers: [],
-                            },
+                            modifiers: None,
                             function: Keyword {
                                 value: "function",
                                 position: 386,

--- a/tests/samples/0094/tree.txt
+++ b/tests/samples/0094/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0094/tree.txt
+++ b/tests/samples/0094/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0094/tree.txt
+++ b/tests/samples/0094/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0095/tree.txt
+++ b/tests/samples/0095/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0095/tree.txt
+++ b/tests/samples/0095/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0095/tree.txt
+++ b/tests/samples/0095/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0096/tree.txt
+++ b/tests/samples/0096/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0096/tree.txt
+++ b/tests/samples/0096/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0096/tree.txt
+++ b/tests/samples/0096/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0097/tree.txt
+++ b/tests/samples/0097/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0097/tree.txt
+++ b/tests/samples/0097/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0097/tree.txt
+++ b/tests/samples/0097/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0098/tree.txt
+++ b/tests/samples/0098/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0098/tree.txt
+++ b/tests/samples/0098/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0098/tree.txt
+++ b/tests/samples/0098/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0099/tree.txt
+++ b/tests/samples/0099/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0099/tree.txt
+++ b/tests/samples/0099/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0099/tree.txt
+++ b/tests/samples/0099/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0100/tree.txt
+++ b/tests/samples/0100/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0100/tree.txt
+++ b/tests/samples/0100/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0100/tree.txt
+++ b/tests/samples/0100/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0101/tree.txt
+++ b/tests/samples/0101/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0101/tree.txt
+++ b/tests/samples/0101/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0101/tree.txt
+++ b/tests/samples/0101/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0102/tree.txt
+++ b/tests/samples/0102/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0102/tree.txt
+++ b/tests/samples/0102/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0102/tree.txt
+++ b/tests/samples/0102/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0103/tree.txt
+++ b/tests/samples/0103/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0103/tree.txt
+++ b/tests/samples/0103/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0103/tree.txt
+++ b/tests/samples/0103/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0104/tree.txt
+++ b/tests/samples/0104/tree.txt
@@ -48,7 +48,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 16,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 16,
@@ -206,7 +209,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 89,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 89,

--- a/tests/samples/0104/tree.txt
+++ b/tests/samples/0104/tree.txt
@@ -2,9 +2,6 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
-                comments: CommentGroup {
-                    comments: [],
-                },
                 attributes: [
                     AttributeGroupDefinition {
                         hash_left_bracket: 1,
@@ -48,6 +45,13 @@ DefinitionTree {
                         right_bracket: 14,
                     },
                 ],
+                comments: CommentGroup {
+                    comments: [],
+                },
+                modifiers: ModifierGroupDefinition {
+                    position: 16,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 16,
@@ -159,9 +163,6 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
-                comments: CommentGroup {
-                    comments: [],
-                },
                 attributes: [
                     AttributeGroupDefinition {
                         hash_left_bracket: 74,
@@ -205,6 +206,13 @@ DefinitionTree {
                         right_bracket: 87,
                     },
                 ],
+                comments: CommentGroup {
+                    comments: [],
+                },
+                modifiers: ModifierGroupDefinition {
+                    position: 89,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 89,

--- a/tests/samples/0104/tree.txt
+++ b/tests/samples/0104/tree.txt
@@ -48,10 +48,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 16,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 16,
@@ -209,10 +206,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 89,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 89,

--- a/tests/samples/0105/tree.txt
+++ b/tests/samples/0105/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0105/tree.txt
+++ b/tests/samples/0105/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0105/tree.txt
+++ b/tests/samples/0105/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0106/tree.txt
+++ b/tests/samples/0106/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0106/tree.txt
+++ b/tests/samples/0106/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0106/tree.txt
+++ b/tests/samples/0106/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0107/code.ara
+++ b/tests/samples/0107/code.ara
@@ -1,7 +1,7 @@
 const Foo ONE = new Foo();
 
 class Foo {
-    const \Closure FOO = fn(): int => 1;
+    const \Closure FOO = static fn(): int => 1;
 
     public static abstract Abstract readonly private static protected string $baz = 'baz';
 

--- a/tests/samples/0107/tree.txt
+++ b/tests/samples/0107/tree.txt
@@ -113,34 +113,44 @@ DefinitionTree {
                                             comments: [],
                                         },
                                         attributes: [],
-                                        static: None,
+                                        modifiers: ModifierGroupDefinition {
+                                            position: 72,
+                                            modifiers: [
+                                                Static(
+                                                    Keyword {
+                                                        value: "static",
+                                                        position: 65,
+                                                    },
+                                                ),
+                                            ],
+                                        },
                                         fn: Keyword {
                                             value: "fn",
-                                            position: 65,
+                                            position: 72,
                                         },
                                         parameters: FunctionLikeParameterListDefinition {
                                             comments: CommentGroup {
                                                 comments: [],
                                             },
-                                            left_parenthesis: 67,
+                                            left_parenthesis: 74,
                                             parameters: CommaSeparated {
                                                 inner: [],
                                                 commas: [],
                                             },
-                                            right_parenthesis: 68,
+                                            right_parenthesis: 75,
                                         },
                                         return_type: FunctionLikeReturnTypeDefinition {
-                                            colon: 69,
+                                            colon: 76,
                                             type_definition: SignedInteger(
                                                 Default(
                                                     Keyword {
                                                         value: "int",
-                                                        position: 71,
+                                                        position: 78,
                                                     },
                                                 ),
                                             ),
                                         },
-                                        double_arrow: 75,
+                                        double_arrow: 82,
                                         body: Literal(
                                             Integer(
                                                 LiteralInteger {
@@ -148,67 +158,67 @@ DefinitionTree {
                                                         comments: [],
                                                     },
                                                     value: "1",
-                                                    position: 78,
+                                                    position: 85,
                                                 },
                                             ),
                                         ),
                                     },
                                 ),
-                                semicolon: 79,
+                                semicolon: 86,
                             },
                         ),
                         Property(
                             PropertyDefinition {
                                 attributes: [],
                                 modifiers: ModifierGroupDefinition {
-                                    position: 152,
+                                    position: 159,
                                     modifiers: [
                                         Public(
                                             Keyword {
                                                 value: "public",
-                                                position: 86,
+                                                position: 93,
                                             },
                                         ),
                                         Static(
                                             Keyword {
                                                 value: "static",
-                                                position: 93,
-                                            },
-                                        ),
-                                        Abstract(
-                                            Keyword {
-                                                value: "abstract",
                                                 position: 100,
                                             },
                                         ),
                                         Abstract(
                                             Keyword {
+                                                value: "abstract",
+                                                position: 107,
+                                            },
+                                        ),
+                                        Abstract(
+                                            Keyword {
                                                 value: "Abstract",
-                                                position: 109,
+                                                position: 116,
                                             },
                                         ),
                                         Readonly(
                                             Keyword {
                                                 value: "readonly",
-                                                position: 118,
+                                                position: 125,
                                             },
                                         ),
                                         Private(
                                             Keyword {
                                                 value: "private",
-                                                position: 127,
+                                                position: 134,
                                             },
                                         ),
                                         Static(
                                             Keyword {
                                                 value: "static",
-                                                position: 135,
+                                                position: 142,
                                             },
                                         ),
                                         Protected(
                                             Keyword {
                                                 value: "protected",
-                                                position: 142,
+                                                position: 149,
                                             },
                                         ),
                                     ],
@@ -216,15 +226,15 @@ DefinitionTree {
                                 type_definition: String(
                                     Keyword {
                                         value: "string",
-                                        position: 152,
+                                        position: 159,
                                     },
                                 ),
                                 entry: Initialized {
                                     variable: Variable {
-                                        position: 159,
+                                        position: 166,
                                         name: "$baz",
                                     },
-                                    equals: 164,
+                                    equals: 171,
                                     value: Literal(
                                         String(
                                             LiteralString {
@@ -232,24 +242,24 @@ DefinitionTree {
                                                     comments: [],
                                                 },
                                                 value: "'baz'",
-                                                position: 166,
+                                                position: 173,
                                             },
                                         ),
                                     ),
                                 },
-                                semicolon: 171,
+                                semicolon: 178,
                             },
                         ),
                         Property(
                             PropertyDefinition {
                                 attributes: [],
                                 modifiers: ModifierGroupDefinition {
-                                    position: 185,
+                                    position: 192,
                                     modifiers: [
                                         Public(
                                             Keyword {
                                                 value: "public",
-                                                position: 178,
+                                                position: 185,
                                             },
                                         ),
                                     ],
@@ -258,51 +268,54 @@ DefinitionTree {
                                     Default(
                                         Keyword {
                                             value: "int",
-                                            position: 185,
+                                            position: 192,
                                         },
                                     ),
                                 ),
                                 entry: Initialized {
                                     variable: Variable {
-                                        position: 189,
+                                        position: 196,
                                         name: "$bar",
                                     },
-                                    equals: 194,
+                                    equals: 201,
                                     value: ArrowFunction(
                                         ArrowFunctionExpression {
                                             comments: CommentGroup {
                                                 comments: [],
                                             },
                                             attributes: [],
-                                            static: None,
+                                            modifiers: ModifierGroupDefinition {
+                                                position: 203,
+                                                modifiers: [],
+                                            },
                                             fn: Keyword {
                                                 value: "fn",
-                                                position: 196,
+                                                position: 203,
                                             },
                                             parameters: FunctionLikeParameterListDefinition {
                                                 comments: CommentGroup {
                                                     comments: [],
                                                 },
-                                                left_parenthesis: 198,
+                                                left_parenthesis: 205,
                                                 parameters: CommaSeparated {
                                                     inner: [],
                                                     commas: [],
                                                 },
-                                                right_parenthesis: 199,
+                                                right_parenthesis: 206,
                                             },
                                             return_type: FunctionLikeReturnTypeDefinition {
-                                                colon: 200,
+                                                colon: 207,
                                                 type_definition: Identifier(
                                                     TemplatedIdentifier {
                                                         name: Identifier {
-                                                            position: 202,
+                                                            position: 209,
                                                             value: "Foo",
                                                         },
                                                         templates: None,
                                                     },
                                                 ),
                                             },
-                                            double_arrow: 206,
+                                            double_arrow: 213,
                                             body: ClassOperation(
                                                 Initialization {
                                                     comments: CommentGroup {
@@ -310,11 +323,11 @@ DefinitionTree {
                                                     },
                                                     new: Keyword {
                                                         value: "new",
-                                                        position: 209,
+                                                        position: 216,
                                                     },
                                                     class: Identifier(
                                                         Identifier {
-                                                            position: 213,
+                                                            position: 220,
                                                             value: "Foo",
                                                         },
                                                     ),
@@ -323,31 +336,31 @@ DefinitionTree {
                                                         comments: CommentGroup {
                                                             comments: [],
                                                         },
-                                                        left_parenthesis: 216,
+                                                        left_parenthesis: 223,
                                                         arguments: CommaSeparated {
                                                             inner: [],
                                                             commas: [],
                                                         },
-                                                        right_parenthesis: 217,
+                                                        right_parenthesis: 224,
                                                     },
                                                 },
                                             ),
                                         },
                                     ),
                                 },
-                                semicolon: 218,
+                                semicolon: 225,
                             },
                         ),
                         Property(
                             PropertyDefinition {
                                 attributes: [],
                                 modifiers: ModifierGroupDefinition {
-                                    position: 232,
+                                    position: 239,
                                     modifiers: [
                                         Public(
                                             Keyword {
                                                 value: "public",
-                                                position: 225,
+                                                position: 232,
                                             },
                                         ),
                                     ],
@@ -356,16 +369,16 @@ DefinitionTree {
                                     Default(
                                         Keyword {
                                             value: "int",
-                                            position: 232,
+                                            position: 239,
                                         },
                                     ),
                                 ),
                                 entry: Initialized {
                                     variable: Variable {
-                                        position: 236,
+                                        position: 243,
                                         name: "$foo",
                                     },
-                                    equals: 241,
+                                    equals: 248,
                                     value: ObjectOperation(
                                         PropertyFetch {
                                             comments: CommentGroup {
@@ -373,26 +386,26 @@ DefinitionTree {
                                             },
                                             object: Variable(
                                                 Variable {
-                                                    position: 243,
+                                                    position: 250,
                                                     name: "$this",
                                                 },
                                             ),
-                                            arrow: 248,
+                                            arrow: 255,
                                             property: Identifier {
-                                                position: 250,
+                                                position: 257,
                                                 value: "bar",
                                             },
                                         },
                                     ),
                                 },
-                                semicolon: 253,
+                                semicolon: 260,
                             },
                         ),
                     ],
-                    right_brace: 255,
+                    right_brace: 262,
                 },
             },
         ),
     ],
-    eof: 257,
+    eof: 264,
 }

--- a/tests/samples/0108/tree.txt
+++ b/tests/samples/0108/tree.txt
@@ -169,10 +169,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 135,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 135,
@@ -242,10 +246,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 187,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 187,
@@ -315,10 +323,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 260,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 260,
@@ -388,10 +400,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 312,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 312,
@@ -461,10 +477,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 355,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 355,
@@ -534,10 +554,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 393,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 393,
@@ -607,10 +631,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 429,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 429,
@@ -680,10 +708,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 483,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 483,
@@ -753,10 +785,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 526,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 526,
@@ -826,10 +862,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 564,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 564,
@@ -899,10 +939,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 600,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 600,
@@ -972,10 +1016,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 648,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 648,
@@ -1045,10 +1093,14 @@ DefinitionTree {
         ),
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 704,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 704,

--- a/tests/samples/0108/tree.txt
+++ b/tests/samples/0108/tree.txt
@@ -173,7 +173,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 135,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 135,
@@ -247,7 +250,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 187,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 187,
@@ -321,7 +327,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 260,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 260,
@@ -395,7 +404,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 312,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 312,
@@ -469,7 +481,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 355,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 355,
@@ -543,7 +558,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 393,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 393,
@@ -617,7 +635,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 429,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 429,
@@ -691,7 +712,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 483,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 483,
@@ -765,7 +789,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 526,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 526,
@@ -839,7 +866,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 564,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 564,
@@ -913,7 +943,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 600,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 600,
@@ -987,7 +1020,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 648,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 648,
@@ -1061,7 +1097,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 704,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 704,

--- a/tests/samples/0108/tree.txt
+++ b/tests/samples/0108/tree.txt
@@ -173,10 +173,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 135,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 135,
@@ -250,10 +247,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 187,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 187,
@@ -327,10 +321,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 260,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 260,
@@ -404,10 +395,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 312,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 312,
@@ -481,10 +469,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 355,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 355,
@@ -558,10 +543,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 393,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 393,
@@ -635,10 +617,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 429,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 429,
@@ -712,10 +691,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 483,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 483,
@@ -789,10 +765,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 526,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 526,
@@ -866,10 +839,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 564,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 564,
@@ -943,10 +913,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 600,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 600,
@@ -1020,10 +987,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 648,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 648,
@@ -1097,10 +1061,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 704,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 704,

--- a/tests/samples/0109/tree.txt
+++ b/tests/samples/0109/tree.txt
@@ -2,10 +2,14 @@ DefinitionTree {
     definitions: [
         Function(
             FunctionDefinition {
+                attributes: [],
                 comments: CommentGroup {
                     comments: [],
                 },
-                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0109/tree.txt
+++ b/tests/samples/0109/tree.txt
@@ -6,10 +6,7 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 0,
-                    modifiers: [],
-                },
+                modifiers: None,
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0109/tree.txt
+++ b/tests/samples/0109/tree.txt
@@ -6,7 +6,10 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: None,
+                modifiers: ModifierGroupDefinition {
+                    position: 0,
+                    modifiers: [],
+                },
                 function: Keyword {
                     value: "function",
                     position: 0,

--- a/tests/samples/0110/code.ara
+++ b/tests/samples/0110/code.ara
@@ -1,0 +1,9 @@
+async function baz(): string {
+    return foo();
+}
+    
+final class Foo {
+    async public function bar(): string {
+        return bar();
+    }
+}

--- a/tests/samples/0110/code.ara
+++ b/tests/samples/0110/code.ara
@@ -6,4 +6,8 @@ final class Foo {
     async public function bar(): string {
         return bar();
     }
+    
+    async public static function baz(): string {
+        return baz();
+    }
 }

--- a/tests/samples/0110/tree.txt
+++ b/tests/samples/0110/tree.txt
@@ -1,0 +1,244 @@
+DefinitionTree {
+    definitions: [
+        Function(
+            FunctionDefinition {
+                attributes: [],
+                comments: CommentGroup {
+                    comments: [],
+                },
+                modifiers: ModifierGroupDefinition {
+                    position: 6,
+                    modifiers: [
+                        Async(
+                            Keyword {
+                                value: "async",
+                                position: 0,
+                            },
+                        ),
+                    ],
+                },
+                function: Keyword {
+                    value: "function",
+                    position: 6,
+                },
+                name: Identifier {
+                    position: 15,
+                    value: "baz",
+                },
+                templates: None,
+                parameters: FunctionLikeParameterListDefinition {
+                    comments: CommentGroup {
+                        comments: [],
+                    },
+                    left_parenthesis: 18,
+                    parameters: CommaSeparated {
+                        inner: [],
+                        commas: [],
+                    },
+                    right_parenthesis: 19,
+                },
+                return_type: FunctionLikeReturnTypeDefinition {
+                    colon: 20,
+                    type_definition: String(
+                        Keyword {
+                            value: "string",
+                            position: 22,
+                        },
+                    ),
+                },
+                body: BlockStatement {
+                    comments: CommentGroup {
+                        comments: [],
+                    },
+                    left_brace: 29,
+                    statements: [
+                        Return(
+                            Explicit {
+                                comments: CommentGroup {
+                                    comments: [],
+                                },
+                                return: Keyword {
+                                    value: "return",
+                                    position: 35,
+                                },
+                                expression: Some(
+                                    FunctionOperation(
+                                        Call {
+                                            comments: CommentGroup {
+                                                comments: [],
+                                            },
+                                            function: Identifier(
+                                                Identifier {
+                                                    position: 42,
+                                                    value: "foo",
+                                                },
+                                            ),
+                                            generics: None,
+                                            arguments: ArgumentListExpression {
+                                                comments: CommentGroup {
+                                                    comments: [],
+                                                },
+                                                left_parenthesis: 45,
+                                                arguments: CommaSeparated {
+                                                    inner: [],
+                                                    commas: [],
+                                                },
+                                                right_parenthesis: 46,
+                                            },
+                                        },
+                                    ),
+                                ),
+                                semicolon: 47,
+                            },
+                        ),
+                    ],
+                    right_brace: 49,
+                },
+            },
+        ),
+        Class(
+            ClassDefinition {
+                comments: CommentGroup {
+                    comments: [],
+                },
+                attributes: [],
+                modifiers: ModifierGroupDefinition {
+                    position: 62,
+                    modifiers: [
+                        Final(
+                            Keyword {
+                                value: "final",
+                                position: 56,
+                            },
+                        ),
+                    ],
+                },
+                class: Keyword {
+                    value: "class",
+                    position: 62,
+                },
+                name: Identifier {
+                    position: 68,
+                    value: "Foo",
+                },
+                templates: None,
+                extends: None,
+                implements: None,
+                body: ClassDefinitionBody {
+                    left_brace: 72,
+                    members: [
+                        Method(
+                            MethodDefinition {
+                                comments: CommentGroup {
+                                    comments: [],
+                                },
+                                attributes: [],
+                                modifiers: ModifierGroupDefinition {
+                                    position: 91,
+                                    modifiers: [
+                                        Async(
+                                            Keyword {
+                                                value: "async",
+                                                position: 78,
+                                            },
+                                        ),
+                                        Public(
+                                            Keyword {
+                                                value: "public",
+                                                position: 84,
+                                            },
+                                        ),
+                                    ],
+                                },
+                                function: Keyword {
+                                    value: "function",
+                                    position: 91,
+                                },
+                                name: Identifier {
+                                    position: 100,
+                                    value: "bar",
+                                },
+                                templates: None,
+                                parameters: MethodParameterListDefinition {
+                                    comments: CommentGroup {
+                                        comments: [],
+                                    },
+                                    left_parenthesis: 103,
+                                    parameters: CommaSeparated {
+                                        inner: [],
+                                        commas: [],
+                                    },
+                                    right_parenthesis: 104,
+                                },
+                                return_type: Some(
+                                    FunctionLikeReturnTypeDefinition {
+                                        colon: 105,
+                                        type_definition: String(
+                                            Keyword {
+                                                value: "string",
+                                                position: 107,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                constraints: None,
+                                body: Concrete(
+                                    BlockStatement {
+                                        comments: CommentGroup {
+                                            comments: [],
+                                        },
+                                        left_brace: 114,
+                                        statements: [
+                                            Return(
+                                                Explicit {
+                                                    comments: CommentGroup {
+                                                        comments: [],
+                                                    },
+                                                    return: Keyword {
+                                                        value: "return",
+                                                        position: 124,
+                                                    },
+                                                    expression: Some(
+                                                        FunctionOperation(
+                                                            Call {
+                                                                comments: CommentGroup {
+                                                                    comments: [],
+                                                                },
+                                                                function: Identifier(
+                                                                    Identifier {
+                                                                        position: 131,
+                                                                        value: "bar",
+                                                                    },
+                                                                ),
+                                                                generics: None,
+                                                                arguments: ArgumentListExpression {
+                                                                    comments: CommentGroup {
+                                                                        comments: [],
+                                                                    },
+                                                                    left_parenthesis: 134,
+                                                                    arguments: CommaSeparated {
+                                                                        inner: [],
+                                                                        commas: [],
+                                                                    },
+                                                                    right_parenthesis: 135,
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    semicolon: 136,
+                                                },
+                                            ),
+                                        ],
+                                        right_brace: 142,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    right_brace: 144,
+                },
+            },
+        ),
+    ],
+    eof: 146,
+}

--- a/tests/samples/0110/tree.txt
+++ b/tests/samples/0110/tree.txt
@@ -6,19 +6,17 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: Some(
-                    ModifierGroupDefinition {
-                        position: 6,
-                        modifiers: [
-                            Async(
-                                Keyword {
-                                    value: "async",
-                                    position: 0,
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                modifiers: ModifierGroupDefinition {
+                    position: 6,
+                    modifiers: [
+                        Async(
+                            Keyword {
+                                value: "async",
+                                position: 0,
+                            },
+                        ),
+                    ],
+                },
                 function: Keyword {
                     value: "function",
                     position: 6,

--- a/tests/samples/0110/tree.txt
+++ b/tests/samples/0110/tree.txt
@@ -234,11 +234,124 @@ DefinitionTree {
                                 ),
                             },
                         ),
+                        Method(
+                            MethodDefinition {
+                                comments: CommentGroup {
+                                    comments: [],
+                                },
+                                attributes: [],
+                                modifiers: ModifierGroupDefinition {
+                                    position: 173,
+                                    modifiers: [
+                                        Async(
+                                            Keyword {
+                                                value: "async",
+                                                position: 153,
+                                            },
+                                        ),
+                                        Public(
+                                            Keyword {
+                                                value: "public",
+                                                position: 159,
+                                            },
+                                        ),
+                                        Static(
+                                            Keyword {
+                                                value: "static",
+                                                position: 166,
+                                            },
+                                        ),
+                                    ],
+                                },
+                                function: Keyword {
+                                    value: "function",
+                                    position: 173,
+                                },
+                                name: Identifier {
+                                    position: 182,
+                                    value: "baz",
+                                },
+                                templates: None,
+                                parameters: MethodParameterListDefinition {
+                                    comments: CommentGroup {
+                                        comments: [],
+                                    },
+                                    left_parenthesis: 185,
+                                    parameters: CommaSeparated {
+                                        inner: [],
+                                        commas: [],
+                                    },
+                                    right_parenthesis: 186,
+                                },
+                                return_type: Some(
+                                    FunctionLikeReturnTypeDefinition {
+                                        colon: 187,
+                                        type_definition: String(
+                                            Keyword {
+                                                value: "string",
+                                                position: 189,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                constraints: None,
+                                body: Concrete(
+                                    BlockStatement {
+                                        comments: CommentGroup {
+                                            comments: [],
+                                        },
+                                        left_brace: 196,
+                                        statements: [
+                                            Return(
+                                                Explicit {
+                                                    comments: CommentGroup {
+                                                        comments: [],
+                                                    },
+                                                    return: Keyword {
+                                                        value: "return",
+                                                        position: 206,
+                                                    },
+                                                    expression: Some(
+                                                        FunctionOperation(
+                                                            Call {
+                                                                comments: CommentGroup {
+                                                                    comments: [],
+                                                                },
+                                                                function: Identifier(
+                                                                    Identifier {
+                                                                        position: 213,
+                                                                        value: "baz",
+                                                                    },
+                                                                ),
+                                                                generics: None,
+                                                                arguments: ArgumentListExpression {
+                                                                    comments: CommentGroup {
+                                                                        comments: [],
+                                                                    },
+                                                                    left_parenthesis: 216,
+                                                                    arguments: CommaSeparated {
+                                                                        inner: [],
+                                                                        commas: [],
+                                                                    },
+                                                                    right_parenthesis: 217,
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    semicolon: 218,
+                                                },
+                                            ),
+                                        ],
+                                        right_brace: 224,
+                                    },
+                                ),
+                            },
+                        ),
                     ],
-                    right_brace: 144,
+                    right_brace: 226,
                 },
             },
         ),
     ],
-    eof: 146,
+    eof: 228,
 }

--- a/tests/samples/0110/tree.txt
+++ b/tests/samples/0110/tree.txt
@@ -6,17 +6,19 @@ DefinitionTree {
                 comments: CommentGroup {
                     comments: [],
                 },
-                modifiers: ModifierGroupDefinition {
-                    position: 6,
-                    modifiers: [
-                        Async(
-                            Keyword {
-                                value: "async",
-                                position: 0,
-                            },
-                        ),
-                    ],
-                },
+                modifiers: Some(
+                    ModifierGroupDefinition {
+                        position: 6,
+                        modifiers: [
+                            Async(
+                                Keyword {
+                                    value: "async",
+                                    position: 0,
+                                },
+                            ),
+                        ],
+                    },
+                ),
                 function: Keyword {
                     value: "function",
                     position: 6,


### PR DESCRIPTION
Changes:

- allow `async` as a modifier for methods and functions.
- remove `r#static` in favor of `modifiers` for short and anonymous functions