### PR TITLE
new: add `new()` for `Tree` and `TreeMap`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -42,7 +42,7 @@ pub fn parse_map(map: &SourceMap) -> Result<TreeMap, Box<Report>> {
             )),
         }))
     } else {
-        Ok(TreeMap { trees })
+        Ok(TreeMap::new(trees))
     }
 }
 
@@ -69,8 +69,5 @@ pub fn construct(source: &Source, tokens: &[Token]) -> Result<Tree, Box<Report>>
 
     let definitions = definition::tree(&mut state)?;
 
-    state.finish(Tree {
-        source: source.name().to_string(),
-        definitions,
-    })
+    state.finish(Tree::new(source.name(), definitions))
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -17,10 +17,25 @@ pub struct TreeMap {
     pub trees: Vec<Tree>,
 }
 
+impl TreeMap {
+    pub fn new(trees: Vec<Tree>) -> Self {
+        Self { trees }
+    }
+}
+
 #[derive(Debug)]
 pub struct Tree {
     pub source: String,
     pub definitions: DefinitionTree,
+}
+
+impl Tree {
+    pub fn new<S: Into<String>>(source: S, definitions: DefinitionTree) -> Self {
+        Self {
+            source: source.into(),
+            definitions,
+        }
+    }
 }
 
 pub trait Node: Any {


### PR DESCRIPTION
In other crates, we use `new()` as a default mechanism to create an instance. So, I thought this could be a good idea here.